### PR TITLE
Upgrade puma and add gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.log
+
+.bundle
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem 'puma'
-gem 'sinatra'
+gem 'puma', '~> 5.2.1'
+gem 'sinatra', '~> 2.1.0'
 
 group :development do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,36 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.5)
+    puma (5.2.1)
       nio4r (~> 2.0)
     rack (2.2.3)
-    rack-protection (2.0.8.1)
+    rack-protection (2.1.0)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (13.0.1)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rake (13.0.3)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
-    ruby2_keywords (0.0.2)
-    sinatra (2.0.8.1)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    ruby2_keywords (0.0.4)
+    sinatra (2.1.0)
       mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.8.1)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
       tilt (~> 2.0)
     tilt (2.0.10)
 
@@ -38,11 +38,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  puma
+  puma (~> 5.2.1)
   rack-test
   rake
   rspec
-  sinatra
+  sinatra (~> 2.1.0)
 
 BUNDLED WITH
    2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ namespace :server do
   desc 'Start the app'
   task :start do
     system "rm test-server-*.log"
-    system "bundle exec puma -d --control tcp://127.0.0.1:9293 --control-token foo config.ru --redirect-stdout test-server-stdout.log --redirect-stderr test-server-stderr.log"
+    system "bundle exec puma --control-url tcp://127.0.0.1:9293 --control-token foo config.ru --redirect-stdout test-server-stdout.log --redirect-stderr test-server-stderr.log"
   end
 
   desc 'Restart the app'


### PR DESCRIPTION
This pr fix an error in MAC OS catalina while running bundler install

I couldn't install puma

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/benjamin.tarenne/repository/beach/joi-energy-ruby/vendor/bundle/ruby/2.7.0/gems/puma-4.3.5/ext/puma_http11
/Users/benjamin.tarenne/.rbenv/versions/2.7.1/bin/ruby -I /Users/benjamin.tarenne/.rbenv/versions/2.7.1/lib/ruby/2.7.0 -r ./siteconf20210217-77930-3vrn9s.rb extconf.rb
checking for BIO_read() in -lcrypto... yes
checking for SSL_CTX_new() in -lssl... yes
checking for openssl/bio.h... yes
checking for DTLS_method() in openssl/ssl.h... yes
checking for TLS_server_method() in openssl/ssl.h... yes
checking for SSL_CTX_set_min_proto_version in openssl/ssl.h... yes
creating Makefile

current directory: /Users/benjamin.tarenne/repository/beach/joi-energy-ruby/vendor/bundle/ruby/2.7.0/gems/puma-4.3.5/ext/puma_http11
make "DESTDIR=" clean

current directory: /Users/benjamin.tarenne/repository/beach/joi-energy-ruby/vendor/bundle/ruby/2.7.0/gems/puma-4.3.5/ext/puma_http11
make "DESTDIR="
compiling http11_parser.c
ext/puma_http11/http11_parser.c:44:18: warning: unused variable 'puma_parser_en_main' [-Wunused-const-variable]
static const int puma_parser_en_main = 1;
                 ^
1 warning generated.
compiling io_buffer.c
compiling mini_ssl.c
mini_ssl.c:145:7: warning: unused variable 'min' [-Wunused-variable]
  int min, ssl_options;
      ^
mini_ssl.c:299:40: warning: function 'raise_error' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
void raise_error(SSL* ssl, int result) {
                                       ^
2 warnings generated.
compiling puma_http11.c
puma_http11.c:203:22: error: implicitly declaring library function 'isspace' with type 'int (int)' [-Werror,-Wimplicit-function-declaration]
  while (vlen > 0 && isspace(value[vlen - 1])) vlen--;
                     ^
puma_http11.c:203:22: note: include the header <ctype.h> or explicitly provide a declaration for 'isspace'
1 error generated.
make: *** [puma_http11.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/benjamin.tarenne/repository/beach/joi-energy-ruby/vendor/bundle/ruby/2.7.0/gems/puma-4.3.5 for inspection.
Results logged to /Users/benjamin.tarenne/repository/beach/joi-energy-ruby/vendor/bundle/ruby/2.7.0/extensions/x86_64-darwin-19/2.7.0/puma-4.3.5/gem_make.out

An error occurred while installing puma (4.3.5), and Bundler cannot continue.
Make sure that `gem install puma -v '4.3.5' --source 'https://rubygems.org/'` succeeds before bundling.
```